### PR TITLE
fix: force disable live metrics if insights disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,24 @@ A [systemic](https://github.com/guidesmiths/systemic) component to use the azure
 
 Forked package of guidesmiths' [systemic-azure-metrics](https://github.com/guidesmiths/systemic-azure-metrics).
 
-Added features:
+Added config flags:
 
-- ignore specific URIs in telemetry
-- up-to-date with latest azure metrics/insights SDK
-- live metrics
+- liveMetrics (`boolean`, default `false`): enable/disable the live metrics stream for insights: https://docs.microsoft.com/en-us/azure/azure-monitor/app/live-stream
+- ignoreURI (`string[]`, default `['/__/manifest]'`) is an array of URIs to be ignored: telemetry won't be sent for that specific requesta
+- traceW3C (`boolean`, default `false`): enable/disable correlation via W3C: https://docs.microsoft.com/en-us/azure/azure-monitor/app/correlation && https://w3c.github.io/trace-context/
+
+
+**WARNING:**
+
+Do not forget to disable appInsights in test mode as it can lead to wrong behaviours/broken tests
+
+eg:
+
+```
+  metrics: {
+    key: 'fakeTestKey',
+    insightsConfig: {
+      disableAppInsights: true
+    }
+  }
+```

--- a/index.js
+++ b/index.js
@@ -35,6 +35,8 @@ module.exports = () => {
     } = config;
     if (!key) throw new Error('No insights key has been provided!');
 
+    const { disableAppInsights } = insightsConfig;
+
     const requestURIFilter = (envelope) => {
       const { data: { baseType, baseData } } = envelope;
 
@@ -60,7 +62,8 @@ module.exports = () => {
       .setAutoCollectExceptions(exceptions)
       .setAutoCollectDependencies(dependencies)
       .setAutoCollectConsole(console, console)
-      .setSendLiveMetrics(liveMetrics)
+      // Apparently live metrics are not being disabled when disabling app insights altogether
+      .setSendLiveMetrics(disableAppInsights ? false : liveMetrics)
       .setDistributedTracingMode(distributedTracingMode)
       .start();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "systemic-azure-metrics",
+  "name": "@infinitaslearning/systemic-azure-metrics",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -13,9 +13,9 @@
       }
     },
     "@azure/core-asynciterator-polyfill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
-      "integrity": "sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.2.tgz",
+      "integrity": "sha512-3rkP4LnnlWawl0LZptJOdXNrT/fHp2eQMadoasa6afspXdpGrtPZuAQc2PD0cpgyuoXtUWyC3tv7xfntjGS5Dw=="
     },
     "@azure/core-auth": {
       "version": "1.3.2",
@@ -27,19 +27,19 @@
       }
     },
     "@azure/core-http": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-2.0.0.tgz",
-      "integrity": "sha512-VBOfUh0z9ZF1WVqrLCtiGWMjkKic171p6mLXRkJKu+p5wuQTb4cU3bPq7nB6UuGAK17LI7hnU0SzydlCQrBuOw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-2.2.4.tgz",
+      "integrity": "sha512-QmmJmexXKtPyc3/rsZR/YTLDvMatzbzAypJmLzvlfxgz/SkgnqV/D4f6F2LsK6tBj1qhyp8BoXiOebiej0zz3A==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-asynciterator-polyfill": "^1.0.0",
         "@azure/core-auth": "^1.3.0",
-        "@azure/core-tracing": "1.0.0-preview.12",
+        "@azure/core-tracing": "1.0.0-preview.13",
         "@azure/logger": "^1.0.0",
         "@types/node-fetch": "^2.5.0",
-        "@types/tunnel": "^0.0.1",
-        "form-data": "^3.0.0",
-        "node-fetch": "^2.6.0",
+        "@types/tunnel": "^0.0.3",
+        "form-data": "^4.0.0",
+        "node-fetch": "^2.6.7",
         "process": "^0.11.10",
         "tough-cookie": "^4.0.0",
         "tslib": "^2.2.0",
@@ -49,20 +49,20 @@
       }
     },
     "@azure/core-tracing": {
-      "version": "1.0.0-preview.12",
-      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.12.tgz",
-      "integrity": "sha512-nvo2Wc4EKZGN6eFu9n3U7OXmASmL8VxoPIH7xaD6OlQqi44bouF0YIi9ID5rEsKLiAU59IYx6M297nqWVMWPDg==",
+      "version": "1.0.0-preview.13",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
+      "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
       "requires": {
-        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/api": "^1.0.1",
         "tslib": "^2.2.0"
       }
     },
     "@azure/logger": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.2.tgz",
-      "integrity": "sha512-YZNjNV0vL3nN2nedmcjQBcpCTo3oqceXmgiQtEm6fLpucjRZyQKAQruhCmCpRlB1iykqKJJ/Y8CDmT5rIE6IJw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
+      "integrity": "sha512-aK4s3Xxjrx3daZr3VylxejK3vG5ExXck5WOHDJ8in/k9AqlfIyFMMT1uG7u8mNjX+QRILTIn0/Xgschfh/dQ9g==",
       "requires": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.2.0"
       }
     },
     "@eslint/eslintrc": {
@@ -138,43 +138,41 @@
       }
     },
     "@opentelemetry/api": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.1.tgz",
-      "integrity": "sha512-H5Djcc2txGAINgf3TNaq4yFofYSIK3722PM89S/3R8FuI/eqi1UscajlXk7EBkG9s2pxss/q6SHlpturaavXaw=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
+      "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog=="
     },
     "@opentelemetry/core": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.23.0.tgz",
-      "integrity": "sha512-7COVsnGEW96ITjc0waWYo/R27sFqjPUg4SCoP8XL48zAGr9zjzeuJoQe/xVchs7op//qOeeEEeBxiBvXy2QS0Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+      "integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "0.23.0",
-        "semver": "^7.1.3"
+        "@opentelemetry/semantic-conventions": "1.0.1"
       }
     },
     "@opentelemetry/resources": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.23.0.tgz",
-      "integrity": "sha512-sAiaoQ0pOwjaaKySuwCUlvej/W9M5d+SxpcuBFUBUojqRlEAYDbx1FHClPnKtOysIb9rXJDQvM3xlH++7NQQzg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.0.1.tgz",
+      "integrity": "sha512-p8DevOaAEepPucUtImR4cZKHOE2L1jgQAtkdZporV+XnxPA/HqCHPEESyUVuo4f5M0NUlL6k5Pba75KwNJlTRg==",
       "requires": {
-        "@opentelemetry/core": "0.23.0",
-        "@opentelemetry/semantic-conventions": "0.23.0"
+        "@opentelemetry/core": "1.0.1",
+        "@opentelemetry/semantic-conventions": "1.0.1"
+      }
+    },
+    "@opentelemetry/sdk-trace-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.0.1.tgz",
+      "integrity": "sha512-JVSAepTpW7dnqfV7XFN0zHj1jXGNd5OcvIGQl76buogqffdgJdgJWQNrOuUJaus56zrOtlzqFH+YtMA9RGEg8w==",
+      "requires": {
+        "@opentelemetry/core": "1.0.1",
+        "@opentelemetry/resources": "1.0.1",
+        "@opentelemetry/semantic-conventions": "1.0.1"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.23.0.tgz",
-      "integrity": "sha512-Tzo+VGR1zlzLbjVI+7mlDJ2xuaUsue4scWvFlK+fzcUfn9siF4NWbxoC2X6Br2B/g4dsq1OAwAYsPVYIEoY2rQ=="
-    },
-    "@opentelemetry/tracing": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.23.0.tgz",
-      "integrity": "sha512-3vNLS55bE0CG1RBDz7+wAAKpLjbl8fhQKqM4MvTy/LYHSolgyM5BNutSb/TcA9LtWvkdI0djgFXxeRig1OFqoQ==",
-      "requires": {
-        "@opentelemetry/core": "0.23.0",
-        "@opentelemetry/resources": "0.23.0",
-        "@opentelemetry/semantic-conventions": "0.23.0",
-        "lodash.merge": "^4.6.2"
-      }
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+      "integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg=="
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -183,23 +181,35 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.1.tgz",
-      "integrity": "sha512-N87VuQi7HEeRJkhzovao/JviiqKjDKMVKxKMfUvSKw+MbkbW8R0nA3fi/MQhhlxV2fQ+2ReM+/Nt4efdrJx3zA=="
+      "version": "17.0.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.19.tgz",
+      "integrity": "sha512-PfeQhvcMR4cPFVuYfBN4ifG7p9c+Dlh3yUZR6k+5yQK7wX3gDgVxBly4/WkBRs9x4dmcy1TVl08SY67wwtEvmA=="
     },
     "@types/node-fetch": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.11.tgz",
-      "integrity": "sha512-2upCKaqVZETDRb8A2VTaRymqFBEgH8u6yr96b/u3+1uQEPDRo3mJLEiPk7vdXBHRtjwkjqzFYMJXrt0Z9QsYjQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==",
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "@types/tunnel": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
-      "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.3.tgz",
+      "integrity": "sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==",
       "requires": {
         "@types/node": "*"
       }
@@ -262,17 +272,19 @@
       }
     },
     "applicationinsights": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.1.4.tgz",
-      "integrity": "sha512-5cMAyW7jwHvdrKk4KU9VD6GR4o5D458KbdmAKKRp9SP9UNuY4pQHJoX60EmE14IlCXbIJd9CWUPhF4xQpCcwoQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.2.1.tgz",
+      "integrity": "sha512-N6panMyjw6E6ayCgjFDBmL/NkaolgBgeX1iJ0jh50E6wrncVJBCa+I4IelwwOfJ4Dl9BWzOSLjp84wTiUyhNwg==",
       "requires": {
-        "@azure/core-http": "^2.0.0",
-        "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/tracing": "^0.23.0",
+        "@azure/core-http": "^2.2.3",
+        "@opentelemetry/api": "^1.0.4",
+        "@opentelemetry/core": "^1.0.1",
+        "@opentelemetry/sdk-trace-base": "^1.0.1",
+        "@opentelemetry/semantic-conventions": "^1.0.1",
         "cls-hooked": "^4.2.2",
         "continuation-local-storage": "^3.2.1",
-        "diagnostic-channel": "1.0.0",
-        "diagnostic-channel-publishers": "1.0.1"
+        "diagnostic-channel": "1.1.0",
+        "diagnostic-channel-publishers": "1.0.4"
       }
     },
     "applicationinsights-native-metrics": {
@@ -519,9 +531,9 @@
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "diagnostic-channel": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.0.0.tgz",
-      "integrity": "sha512-v7Clmg5HG9XwIhqgbBRfwFzwZhxjvESZ33uu1cgcCLkdb9ZxgtY78eAgQMEQ39UecQ//4K5W75iq6LFBtAQD8w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.0.tgz",
+      "integrity": "sha512-fwujyMe1gj6rk6dYi9hMZm0c8Mz8NDMVl2LB4iaYh3+LIAThZC8RKFGXWG0IML2OxAit/ZFRgZhMkhQ3d/bobQ==",
       "requires": {
         "semver": "^5.3.0"
       },
@@ -534,9 +546,9 @@
       }
     },
     "diagnostic-channel-publishers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.1.tgz",
-      "integrity": "sha512-9D6XicU15MLXVtYEaBc3q1Di/4ciUFMULApfBc8/RUUwBk7g16t7/aFKZF4Kt4B3aFBtCbsTYJRAMKCSFaYWDA=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.4.tgz",
+      "integrity": "sha512-GDRAOrcNTPk4DhYzM2BauMnq7nKdFWmSFjWnEu8dT8Xf/ZXUbpORrqNAhIWsy2tqRjHG7QkmYjMUL4/EGSM2GA=="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -982,9 +994,9 @@
       "dev": true
     },
     "form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -1375,7 +1387,8 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -1401,16 +1414,16 @@
       }
     },
     "mime-db": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
     },
     "mime-types": {
-      "version": "2.1.31",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
       "requires": {
-        "mime-db": "1.48.0"
+        "mime-db": "1.51.0"
       }
     },
     "minimatch": {
@@ -1466,9 +1479,12 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "nopt": {
       "version": "5.0.0",
@@ -1867,9 +1883,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "tunnel": {
       "version": "0.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@infinitaslearning/systemic-azure-metrics",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/infinitaslearning/systemic-azure-metrics#readme",
   "dependencies": {
-    "applicationinsights": "^2.1.3",
+    "applicationinsights": "^2.2.1",
     "applicationinsights-native-metrics": "0.0.7",
     "debug": "^4.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infinitaslearning/systemic-azure-metrics",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A systemic plugin to use the azure metrics sdk, forked from guidesmiths version.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This PR disables `liveMetrics` if `disableAppInsights` is being passed in the `insightsConfig` (eg in tests).
Apparently just disabling the appInsights is not enough and the module still tries to send live metrics hence breaking stuff if not using a valid key (eg in tests)

It also includes a version bump of the `applicationinsights` module (`2.1.3 -> 2.2.1`) and a more descriptive README.