### PR TITLE
feat: use dummy client when disabling appInsights

### DIFF
--- a/dummyClient.js
+++ b/dummyClient.js
@@ -1,0 +1,10 @@
+const dummyClient = {
+  trackEvent: () => {},
+  trackException: () => {},
+  trackMetric: () => {},
+  trackTrace: () => {},
+  trackDependency: () => {},
+  trackRequest: () => {}
+};
+
+module.exports = { dummyClient };

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = () => {
   const start = async ({ config }) => {
     const {
       key,
-      internalLogging = true,
+      internalLogging = false,
       liveMetrics = true,
       traceW3C = false,
       ignoreURI = ['/__/manifest'],

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const debug = require('debug')('systemic-azure-metrics');
 const appInsights = require('applicationinsights');
+const { dummyClient } = require('./dummyClient');
 
 module.exports = () => {
   // samplingPercentage, disableAppInsights, etc
@@ -16,7 +17,7 @@ module.exports = () => {
   const start = async ({ config }) => {
     const {
       key,
-      internalLogging = false,
+      internalLogging = true,
       liveMetrics = true,
       traceW3C = false,
       ignoreURI = ['/__/manifest'],
@@ -36,6 +37,15 @@ module.exports = () => {
     if (!key) throw new Error('No insights key has been provided!');
 
     const { disableAppInsights } = insightsConfig;
+
+    // appInsights is NEVER 100% disabled unless we use this hack; eg:
+    // - complains about wrong instrumentation keys
+    // - creates correlationKeys POSTing to Azure endpoint
+    // if you know of any better approach, please shout!
+    if (disableAppInsights) {
+      debug('appInsights disabled: returning dummy client');
+      return dummyClient;
+    }
 
     const requestURIFilter = (envelope) => {
       const { data: { baseType, baseData } } = envelope;
@@ -62,8 +72,7 @@ module.exports = () => {
       .setAutoCollectExceptions(exceptions)
       .setAutoCollectDependencies(dependencies)
       .setAutoCollectConsole(console, console)
-      // Apparently live metrics are not being disabled when disabling app insights altogether
-      .setSendLiveMetrics(disableAppInsights ? false : liveMetrics)
+      .setSendLiveMetrics(liveMetrics)
       .setDistributedTracingMode(distributedTracingMode)
       .start();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@infinitaslearning/systemic-azure-metrics",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infinitaslearning/systemic-azure-metrics",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A systemic plugin to use the azure metrics sdk, forked from guidesmiths version.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
For some unknown reason, the `appinsights` is **never** being really disabled.

It does complain about invalid instrumentation keys (even when setting `disableAppInsights` as a config value) and, when enabling `internalLogging`, you will notice that the module tries to get `correlationKeys` from Azure endpoints and generates network traffic.

I have also tried to skip the `.start()` of the module, tuned down the sampling to 0% and few other things but it's still communicating with Azure endpoints on startup.

This is probably not the cleanest of the approaches but it should fit, given we're basically disabling `appInsights` only in the tests.
